### PR TITLE
fix: add missing import in ReviewsDAO

### DIFF
--- a/server/src/repository/ReviewsDAO.js
+++ b/server/src/repository/ReviewsDAO.js
@@ -6,6 +6,7 @@ const {
   ScanCommand,
   UpdateCommand,
   GetCommand,
+  QueryCommand,
 } = require("@aws-sdk/lib-dynamodb");
 const { logger } = require("../util/logger");
 const { buildQueryParamsForGetReviewsByRecipeId } = require("./ReviewsDAOHelpers");


### PR DESCRIPTION
* Import QueryCommand from @aws-sdk/lib-dynamodb for function getReviewsByRecipeId to use.