### PR TITLE
fix: correctly sort retrieved reviews by recipe ID

### DIFF
--- a/server/__test__/repository/ReviewsDAOHelpers.test.js
+++ b/server/__test__/repository/ReviewsDAOHelpers.test.js
@@ -19,6 +19,7 @@ const REVIEW_ID = "5678";
 const AUTHOR = "author";
 const LIMIT = 10;
 const REVIEWS_TABLENAME = process.env.REVIEWS_TABLENAME;
+const RECIPE_ID_INDEX_NAME = process.env.REVIEWS_TABLE_RECIPEID_INDEXNAME;
 const AUTHOR_INDEX_NAME = process.env.REVIEWS_TABLE_AUTHOR_INDEXNAME;
 const IS_RECENT_INDEX_NAME = process.env.REVIEWS_TABLE_ISRECENT_INDEXNAME;
 
@@ -43,8 +44,10 @@ describe("commandForGetReviewsFactory", () => {
       const EXPECTED_RESULT_OBJECT_TYPE = QC;
       const EXPECTED_COMMAND_ARG = {
         TableName: REVIEWS_TABLENAME,
+        IndexName: RECIPE_ID_INDEX_NAME,
         KeyConditionExpression: "recipeId = :recipeId",
         ExpressionAttributeValues: { ":recipeId": RECIPE_ID },
+        ScanIndexForward: false,
       };
 
       // Act
@@ -69,9 +72,11 @@ describe("commandForGetReviewsFactory", () => {
       const EXPECTED_RESULT_OBJECT_TYPE = QC;
       const EXPECTED_COMMAND_ARG = {
         TableName: REVIEWS_TABLENAME,
+        IndexName: RECIPE_ID_INDEX_NAME,
         ExclusiveStartKey: { recipeId: RECIPE_ID, reviewId: REVIEW_ID },
         KeyConditionExpression: "recipeId = :recipeId",
         ExpressionAttributeValues: { ":recipeId": RECIPE_ID },
+        ScanIndexForward: false,
       };
 
       // Act
@@ -93,9 +98,11 @@ describe("commandForGetReviewsFactory", () => {
     const EXPECTED_RESULT_OBJECT_TYPE = QC;
     const EXPECTED_COMMAND_ARG = {
       TableName: REVIEWS_TABLENAME,
+      IndexName: RECIPE_ID_INDEX_NAME,
       KeyConditionExpression: "recipeId = :recipeId",
       ExpressionAttributeValues: { ":recipeId": RECIPE_ID },
       Limit: LIMIT,
+      ScanIndexForward: false,
     };
 
     // Act
@@ -120,10 +127,12 @@ describe("commandForGetReviewsFactory", () => {
       const EXPECTED_RESULT_OBJECT_TYPE = QC;
       const EXPECTED_COMMAND_ARG = {
         TableName: REVIEWS_TABLENAME,
+        IndexName: RECIPE_ID_INDEX_NAME,
         ExclusiveStartKey: { recipeId: RECIPE_ID, reviewId: REVIEW_ID },
         KeyConditionExpression: "recipeId = :recipeId",
         ExpressionAttributeValues: { ":recipeId": RECIPE_ID },
         Limit: LIMIT,
+        ScanIndexForward: false,
       };
 
       // Act

--- a/server/__test__/service/ReviewsService.test.js
+++ b/server/__test__/service/ReviewsService.test.js
@@ -57,7 +57,7 @@ describe("getReviews", () => {
         // Arrange
         const REQUEST_QUERY_PARAMS = {
           recipeId: RECIPE_ID1,
-          ExclusiveStartKey: { recipeId: RECIPE_ID1, reviewId: REVIEW_ID1 },
+          ExclusiveStartKey: { recipeId: RECIPE_ID1, reviewId: REVIEW_ID1, createdAt: CREATED_AT1 },
           Limit: LIMIT,
         };
         const EXPECTED_PASSED_PROPS = structuredClone(REQUEST_QUERY_PARAMS);
@@ -97,6 +97,7 @@ describe("getReviews", () => {
           ExclusiveStartKey: {
             recipeId: RECIPE_ID1,
             reviewId: REVIEW_ID1,
+            createdAt: CREATED_AT1,
           },
           Limit: MAX_LIMIT,
         };
@@ -134,6 +135,7 @@ describe("getReviews", () => {
         ExclusiveStartKey: {
           recipeId: RECIPE_ID1,
           reviewId: REVIEW_ID1,
+          createdAt: CREATED_AT1,
         },
         Limit: MAX_LIMIT,
       };

--- a/server/src/repository/ReviewsDAOHelpers.js
+++ b/server/src/repository/ReviewsDAOHelpers.js
@@ -3,6 +3,7 @@ const env = require("dotenv").config();
 const { QueryCommand } = require("@aws-sdk/lib-dynamodb");
 
 const TableName = process.env.REVIEWS_TABLENAME;
+const RecipeIdIndexName = process.env.REVIEWS_TABLE_RECIPEID_INDEXNAME;
 const AuthorIndexName = process.env.REVIEWS_TABLE_AUTHOR_INDEXNAME;
 const IsRecentIndexName = process.env.REVIEWS_TABLE_ISRECENT_INDEXNAME;
 
@@ -27,8 +28,10 @@ function commandForGetReviewsFactory({ recipeId, author, ExclusiveStartKey, Limi
   if (recipeId) {
     params = {
       TableName,
+      IndexName: RecipeIdIndexName,
       KeyConditionExpression: "recipeId = :recipeId",
       ExpressionAttributeValues: { ":recipeId": recipeId },
+      ScanIndexForward: false,
     };
   } else if (author) {
     params = {

--- a/server/src/service/ReviewsService.js
+++ b/server/src/service/ReviewsService.js
@@ -68,9 +68,9 @@ async function getReviews(requestQueryParams) {
     PROPS.recipeId = requestQueryParams.recipeId;
 
     if (requestQueryParams.ExclusiveStartKey) {
-      const { recipeId, reviewId } = requestQueryParams.ExclusiveStartKey;
-      if (recipeId && reviewId) {
-        PROPS.ExclusiveStartKey = { recipeId, reviewId };
+      const { recipeId, reviewId, createdAt } = requestQueryParams.ExclusiveStartKey;
+      if (recipeId && reviewId && createdAt) {
+        PROPS.ExclusiveStartKey = { recipeId, reviewId, createdAt };
       }
     }
 


### PR DESCRIPTION
* In ReviewsDAOHelpers.js, utilized a new GSI table for reviews, with index partition key of recipe ID and sort key of creation timestamp.
  - This will allow returning reviews sorted by the most recent review first.

* In ReviewsService.js, updated the required ExclusiveStartKey primary keys to allow continued querying on the GSI.