### PR TITLE
fix: add proper errors for invalid user inputs

### DIFF
--- a/server/__test__/controller/ReviewsRouterHelpers.test.js
+++ b/server/__test__/controller/ReviewsRouterHelpers.test.js
@@ -2,6 +2,7 @@ const {
   sanitizeGetReviewsQueryParams,
   convertUuid,
 } = require("../../src/controller/ReviewsRouterHelpers");
+const ArgumentError = require("../../src/errors/ArgumentError");
 
 // --------------------------------------------------
 
@@ -148,41 +149,35 @@ describe("sanitizeGetReviewsQueryParams", () => {
     expect(RESULT).toStrictEqual(EXPECTED_RESULT);
   });
 
-  test(
-    "Giving an ExclusiveStartKey without a recipeId " +
-      "should return an Object without ExclusiveStartKey.",
-    () => {
-      // Arrange
-      const REQUEST_QUERY_PARAMS = {
-        ExclusiveStartKey: JSON.stringify({ reviewId: UUID }),
-      };
-      const EXPECTED_RESULT = {};
+  test("Giving an ExclusiveStartKey without a recipeId should throw an error.", () => {
+    // Arrange
+    const REQUEST_QUERY_PARAMS = {
+      ExclusiveStartKey: JSON.stringify({ reviewId: UUID }),
+    };
 
-      // Act
-      const RESULT = sanitizeGetReviewsQueryParams(REQUEST_QUERY_PARAMS);
-
-      // Assert
-      expect(RESULT).toStrictEqual(EXPECTED_RESULT);
+    // Act
+    function runFunc() {
+      sanitizeGetReviewsQueryParams(REQUEST_QUERY_PARAMS);
     }
-  );
 
-  test(
-    "Giving an ExclusiveStartKey without a valid reviewId " +
-      "should return an Object without ExclusiveStartKey.",
-    () => {
-      // Arrange
-      const REQUEST_QUERY_PARAMS = {
-        ExclusiveStartKey: JSON.stringify({ recipeId: "77777", reviewId: "8399" }),
-      };
-      const EXPECTED_RESULT = {};
+    // Assert
+    expect(runFunc).toThrow(ArgumentError);
+  });
 
-      // Act
-      const RESULT = sanitizeGetReviewsQueryParams(REQUEST_QUERY_PARAMS);
+  test("Giving an ExclusiveStartKey without a valid reviewId should throw an error.", () => {
+    // Arrange
+    const REQUEST_QUERY_PARAMS = {
+      ExclusiveStartKey: JSON.stringify({ recipeId: "77777", reviewId: "8399" }),
+    };
 
-      // Assert
-      expect(RESULT).toStrictEqual(EXPECTED_RESULT);
+    // Act
+    function runFunc() {
+      sanitizeGetReviewsQueryParams(REQUEST_QUERY_PARAMS);
     }
-  );
+
+    // Assert
+    expect(runFunc).toThrow(ArgumentError);
+  });
 
   test(
     "Giving an ExclusiveStartKey with recipe ID, review ID, and createdAt " +
@@ -207,32 +202,27 @@ describe("sanitizeGetReviewsQueryParams", () => {
     }
   );
 
-  test(
-    "Giving an ExclusiveStartKey with recipe ID, review ID, and author " +
-      "should return an Object with only recipe ID and review ID.",
-    () => {
-      // Arrange
-      const REQUEST_QUERY_PARAMS = {
-        ExclusiveStartKey: JSON.stringify({
-          ...EXCLUSIVE_START_KEY_FOR_BASE_TABLE,
-          author: "user99",
-        }),
-      };
-      const EXPECTED_RESULT = {
-        ExclusiveStartKey: EXCLUSIVE_START_KEY_FOR_BASE_TABLE,
-      };
+  test("Giving an ExclusiveStartKey with recipe ID, review ID, and author should throw an error.", () => {
+    // Arrange
+    const REQUEST_QUERY_PARAMS = {
+      ExclusiveStartKey: JSON.stringify({
+        ...EXCLUSIVE_START_KEY_FOR_BASE_TABLE,
+        author: "user99",
+      }),
+    };
 
-      // Act
-      const RESULT = sanitizeGetReviewsQueryParams(REQUEST_QUERY_PARAMS);
-
-      // Assert
-      expect(RESULT).toStrictEqual(EXPECTED_RESULT);
+    // Act
+    function runFunc() {
+      sanitizeGetReviewsQueryParams(REQUEST_QUERY_PARAMS);
     }
-  );
+
+    // Assert
+    expect(runFunc).toThrow(ArgumentError);
+  });
 
   test(
-    "Giving an ExclusiveStartKey with recipe ID, review ID, author, but with invalid createdAt " +
-      "should return an Object with only recipe ID and review ID.",
+    "Giving an ExclusiveStartKey with recipe ID, review ID, author, " +
+      "but with invalid createdAt should throw an error.",
     () => {
       // Arrange
       const REQUEST_QUERY_PARAMS = {
@@ -242,21 +232,20 @@ describe("sanitizeGetReviewsQueryParams", () => {
           createdAt: "abcd",
         }),
       };
-      const EXPECTED_RESULT = {
-        ExclusiveStartKey: EXCLUSIVE_START_KEY_FOR_BASE_TABLE,
-      };
 
       // Act
-      const RESULT = sanitizeGetReviewsQueryParams(REQUEST_QUERY_PARAMS);
+      function runFunc() {
+        sanitizeGetReviewsQueryParams(REQUEST_QUERY_PARAMS);
+      }
 
       // Assert
-      expect(RESULT).toStrictEqual(EXPECTED_RESULT);
+      expect(runFunc).toThrow(ArgumentError);
     }
   );
 
   test(
-    "Giving an ExclusiveStartKey with recipe ID, review ID, but with invalid createdAt " +
-      "should return an Object with only recipe ID and review ID.",
+    "Giving an ExclusiveStartKey with recipe ID, review ID, but with " +
+      "invalid createdAt should throw an error.",
     () => {
       // Arrange
       const REQUEST_QUERY_PARAMS = {
@@ -265,30 +254,45 @@ describe("sanitizeGetReviewsQueryParams", () => {
           createdAt: "abcd",
         }),
       };
-      const EXPECTED_RESULT = {
-        ExclusiveStartKey: EXCLUSIVE_START_KEY_FOR_BASE_TABLE,
-      };
 
       // Act
-      const RESULT = sanitizeGetReviewsQueryParams(REQUEST_QUERY_PARAMS);
+      function runFunc() {
+        sanitizeGetReviewsQueryParams(REQUEST_QUERY_PARAMS);
+      }
 
       // Assert
-      expect(RESULT).toStrictEqual(EXPECTED_RESULT);
+      expect(runFunc).toThrow(ArgumentError);
     }
   );
 
-  test("Giving an invalid Limit should return an Object without Limit.", () => {
+  test("Giving an unparsable ExclusiveStartKey should throw an error.", () => {
+    // Arrange
+    const REQUEST_QUERY_PARAMS = {
+      ExclusiveStartKey: "{ recipeId }",
+    };
+
+    // Act
+    function runFunc() {
+      sanitizeGetReviewsQueryParams(REQUEST_QUERY_PARAMS);
+    }
+
+    // Assert
+    expect(runFunc).toThrow(ArgumentError);
+  });
+
+  test("Giving an invalid Limit should throw an error.", () => {
     // Arrange
     const REQUEST_QUERY_PARAMS = {
       Limit: "abc",
     };
-    const EXPECTED_RESULT = {};
 
     // Act
-    const RESULT = sanitizeGetReviewsQueryParams(REQUEST_QUERY_PARAMS);
+    function runFunc() {
+      sanitizeGetReviewsQueryParams(REQUEST_QUERY_PARAMS);
+    }
 
     // Assert
-    expect(RESULT).toStrictEqual(EXPECTED_RESULT);
+    expect(runFunc).toThrow(ArgumentError);
   });
 });
 
@@ -305,14 +309,16 @@ describe("convertUuid", () => {
     expect(RESULT).toBe(UUID);
   });
 
-  test("Giving an invalid UUID returns null.", () => {
+  test("Giving an invalid UUID throws an error.", () => {
     // Arrange
     const UUID = "1234567890";
 
     // Act
-    const RESULT = convertUuid(UUID);
+    function runFunc() {
+      convertUuid(UUID);
+    }
 
     // Assert
-    expect(RESULT).toBe(null);
+    expect(runFunc).toThrow(ArgumentError);
   });
 });

--- a/server/__test__/service/ReviewsService.test.js
+++ b/server/__test__/service/ReviewsService.test.js
@@ -1,5 +1,6 @@
 const { getReviews } = require("../../src/service/ReviewsService");
 const ReviewsDAO = require("../../src/repository/ReviewsDAO");
+const ArgumentError = require("../../src/errors/ArgumentError");
 
 // --------------------------------------------------
 
@@ -75,6 +76,29 @@ describe("getReviews", () => {
         expect(RESULT).toEqual(EXPECTED_RESULT);
         expect(getReviewsSpy).toHaveBeenCalledTimes(1);
         expect(getReviewsSpy).toHaveBeenCalledWith(EXPECTED_PASSED_PROPS);
+      }
+    );
+
+    test(
+      "Giving recipe ID and ExclusiveStartKey, but ExclusiveStartKey has too few properties, " +
+        "should throw an error.",
+      async () => {
+        // Arrange
+        const REQUEST_QUERY_PARAMS = {
+          recipeId: RECIPE_ID1,
+          ExclusiveStartKey: {
+            createdAt: CREATED_AT1,
+          },
+        };
+
+        // Act
+        async function runFunc() {
+          await getReviews(REQUEST_QUERY_PARAMS);
+        }
+
+        // Assert
+        expect(runFunc).rejects.toThrow(ArgumentError);
+        expect(getReviewsSpy).not.toHaveBeenCalled();
       }
     );
 
@@ -218,8 +242,8 @@ describe("getReviews", () => {
     );
 
     test(
-      "Giving author and ExclusiveStartKey, but ExclusiveStartKey has too few properties, should not pass the " +
-        "ExclusiveStartKey to the DAO.",
+      "Giving author and ExclusiveStartKey, but ExclusiveStartKey has too few properties, " +
+        "should throw an error.",
       async () => {
         // Arrange
         const REQUEST_QUERY_PARAMS = {
@@ -229,24 +253,15 @@ describe("getReviews", () => {
             createdAt: CREATED_AT1,
           },
         };
-        const EXPECTED_PASSED_PROPS = {
-          author: AUTHOR1,
-          Limit: MAX_LIMIT,
-        };
-        const EXPECTED_RESULT = {
-          items: [{ recipeId: RECIPE_ID1, reviewId: REVIEW_ID2, author: AUTHOR2 }],
-          LastEvaluatedKey: {},
-        };
-
-        getReviewsSpy.mockReturnValueOnce(structuredClone(EXPECTED_RESULT));
 
         // Act
-        const RESULT = await getReviews(REQUEST_QUERY_PARAMS);
+        async function runFunc() {
+          await getReviews(REQUEST_QUERY_PARAMS);
+        }
 
         // Assert
-        expect(RESULT).toEqual(EXPECTED_RESULT);
-        expect(getReviewsSpy).toHaveBeenCalledTimes(1);
-        expect(getReviewsSpy).toHaveBeenCalledWith(EXPECTED_PASSED_PROPS);
+        expect(runFunc).rejects.toThrow(ArgumentError);
+        expect(getReviewsSpy).not.toHaveBeenCalled();
       }
     );
   });
@@ -319,7 +334,7 @@ describe("getReviews", () => {
 
     test(
       "Only giving ExclusiveStartKey, but ExclusiveStartKey has too few properties, " +
-        "should not pass ExclusiveStartKey to the DAO.",
+        "should throw an error.",
       async () => {
         // Arrange
         const REQUEST_QUERY_PARAMS = {
@@ -328,23 +343,15 @@ describe("getReviews", () => {
             reviewId: REVIEW_ID1,
           },
         };
-        const EXPECTED_PASSED_PROPS = {
-          Limit: MAX_LIMIT,
-        };
-        const EXPECTED_RESULT = {
-          items: [{ recipeId: RECIPE_ID1, reviewId: REVIEW_ID2, author: AUTHOR1 }],
-          LastEvaluatedKey: {},
-        };
-
-        getReviewsSpy.mockReturnValueOnce(structuredClone(EXPECTED_RESULT));
 
         // Act
-        const RESULT = await getReviews(REQUEST_QUERY_PARAMS);
+        async function runFunc() {
+          await getReviews(REQUEST_QUERY_PARAMS);
+        }
 
         // Assert
-        expect(RESULT).toEqual(EXPECTED_RESULT);
-        expect(getReviewsSpy).toHaveBeenCalledTimes(1);
-        expect(getReviewsSpy).toHaveBeenCalledWith(EXPECTED_PASSED_PROPS);
+        expect(runFunc).rejects.toThrow(ArgumentError);
+        expect(getReviewsSpy).not.toHaveBeenCalled();
       }
     );
 


### PR DESCRIPTION
Currently, incorrect or invalid URL query parameters were ignored, giving unexpected responses and lists of reviews.  For example, when an ExclusiveStartKey required a createdAt property, but it isn't included, the results returned will be as though an ExclusiveStartKey was not given.  This may lead users to think that the list of reviews returned is the next page of results, when it isn't.