### PR TITLE
feat: add jest config to package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -46,5 +46,10 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "^axios$": "axios/dist/node/axios.cjs"
+    }
   }
 }


### PR DESCRIPTION
This will allow testing the front-end without getting the "SyntaxError: Cannot use import statement outside a module" error.