### PR TITLE
fix: CSS selector for recipe name in review card

### DIFF
--- a/client/src/Components/ReviewCard/ReviewCard.css
+++ b/client/src/Components/ReviewCard/ReviewCard.css
@@ -44,7 +44,7 @@
   border-radius: 0.5em;
 }
 
-.review-card__recipe-name,
+.review-card__recipe-name *,
 .review-card__body--linked *,
 .review-card__profile * {
   text-decoration: none;


### PR DESCRIPTION
The new class "review-card__recipe-name" was given the text-decoration and color rules, when instead it was supposed to be the children of that class.  The rules weren't being applied correctly.